### PR TITLE
openfiber-address-api to 1.0.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: melita-it-eshop-api
   repository: https://chartmuseum.jx.build.melita.it
   version: 1.0.67
+- name: openfiber-address-api
+  repository: https://chartmuseum.jx.build.melita.it
+  version: 1.0.46


### PR DESCRIPTION
Promote openfiber-address-api to version 1.0.46