### PR TITLE
openfiber-address-api to 1.0.50

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 0.0.63
 - name: openfiber-address-api
   repository: https://chartmuseum.jx.build.melita.it
-  version: 1.0.46
+  version: 1.0.50
 - name: ott-service-api
   repository: https://chartmuseum.jx.build.melita.it
   version: 1.0.39


### PR DESCRIPTION
Promote openfiber-address-api to version 1.0.50